### PR TITLE
Update dead links to support.screeps.com

### DIFF
--- a/app/routes/_base+/_wiki+/CPU.mdx
+++ b/app/routes/_base+/_wiki+/CPU.mdx
@@ -27,7 +27,7 @@ Buckets are commonly used to combine multiple, heavier calculations to run inter
 
 ## API CPU Usage
 
-Each API method on the [API Reference](http://support.screeps.com/hc/en-us/articles/203084991-API-Reference) page lists CPU usage of the method ranging from low to High. Methods marked with an A always require .2 CPU because they directly modify the game world. These methods are usually called "intents", since you call them to set an intent to do something that changes the game state and all the intents are later resolved by the server. It is generally suggested to avoid making repeated calls to methods with High CPU usage. Many employ [caching](/Caching) as a mechanism to avoid this.
+Each API method on the [API Reference](https://docs.screeps.com/api/) page lists CPU usage of the method ranging from low to High. Methods marked with an A always require .2 CPU because they directly modify the game world. These methods are usually called "intents", since you call them to set an intent to do something that changes the game state and all the intents are later resolved by the server. It is generally suggested to avoid making repeated calls to methods with High CPU usage. Many employ [caching](/Caching) as a mechanism to avoid this.
 
 ## Managing CPU
 

--- a/app/routes/_base+/_wiki+/Caching.mdx
+++ b/app/routes/_base+/_wiki+/Caching.mdx
@@ -8,7 +8,7 @@ categories:
 
 The Loop Architecture of the server creates a new instance of the "loop" function each tick, but it does not reset items in the global scope. This means that any data can be stored in the global space for future ticks to use.
 
-However, due to the [server architecture](https://support.screeps.com/hc/en-us/articles/205960931-Server-side-architecture-overview), each worker process has it's own global scope. Items entered into or removed in one run will not have their state changed on other workers, which adds considerable constraints on being used to cache volatile data. It does work great for memoization (saving the results of expensive functions where the results are not expected to change).
+However, due to the [server architecture](https://docs.screeps.com/architecture.html), each worker process has it's own global scope. Items entered into or removed in one run will not have their state changed on other workers, which adds considerable constraints on being used to cache volatile data. It does work great for memoization (saving the results of expensive functions where the results are not expected to change).
 
 ## Require Cache
 

--- a/app/routes/_base+/_wiki+/Find_Methods.mdx
+++ b/app/routes/_base+/_wiki+/Find_Methods.mdx
@@ -10,11 +10,11 @@ categories:
 
 Find methods of the Room object will return an array of values or an integer error value, depending on the specific method. It is recommended to check the API prior to using them. Links to the method in the API are provided by clicking on the appropriate method below.
 
-### [Room.find()](https://support.screeps.com/hc/en-us/articles/203079011-Room#find)
+### [Room.find()](https://docs.screeps.com/api/#Room.find)
 
 Returns an array of objects that meet the specifications passed in the arguments. It can be passed a FIND_* constant, and has and optional filter argument.
 
-### [Room.findExitTo()](http://support.screeps.com/hc/en-us/articles/203079011-Room#findExitTo)
+### [Room.findExitTo()](https://docs.screeps.com/api/#Room.findExitTo)
 
 Returns an array of directional exit constants (e.g. FIND_EXIT_TOP) or an integer error value if there is no path or you pass an invalid argument. This is typically used in conjunction with another find method to get specific [RoomPositions](/Map#roomposition) matching the returned exit constants.
 

--- a/app/routes/_base+/_wiki+/Static_Harvesting.mdx
+++ b/app/routes/_base+/_wiki+/Static_Harvesting.mdx
@@ -37,7 +37,7 @@ Some people choose to drop mine at earlier [Room Control Levels](/Room_Control_L
 
 Repairing the container due to its decay can be done by the mining creep, or other workers in the room. If the miner maintains it, it will need at least 1 CARRY part to hold the energy used in the repairs. Once the creep tries to harvest more than it's carryCapacity, it will continue to drop the energy into the container.
 
-[Remote Harvesting](/Remote_Harvesting) and [Source Keeper](/Source_Keeper) mining also often takes the form of container mining to deal with the large amounts of energy mined or higher travel times the carriers require to return the energy to a claimed room. The benefit is less clear in non-owned rooms though, because of the increased (*5) decay rate (see [doc](http://support.screeps.com/hc/en-us/articles/208435885-StructureContainer) )
+[Remote Harvesting](/Remote_Harvesting) and [Source Keeper](/Source_Keeper) mining also often takes the form of container mining to deal with the large amounts of energy mined or higher travel times the carriers require to return the energy to a claimed room. The benefit is less clear in non-owned rooms though, because of the increased (*5) decay rate (see [doc](https://docs.screeps.com/api/#StructureContainer) )
 
 [Mineral Mining](/Mineral_Mining) often takes the form of can mining to minimize the loss of valuable minerals.
 

--- a/app/routes/_base+/_wiki+/StructureSpawn.mdx
+++ b/app/routes/_base+/_wiki+/StructureSpawn.mdx
@@ -7,7 +7,7 @@ categories:
 
 import { Image } from "../../../components/Image"
 
-Please view the [API documentation for StructureSpawn](http://support.screeps.com/hc/en-us/articles/205990342-StructureSpawn).
+Please view the [API documentation for StructureSpawn](https://docs.screeps.com/api/#StructureSpawn).
 
 This page is meant to provide some extra information that is not included in the documentation.
 

--- a/app/routes/_base+/_wiki+/StructureStorage.mdx
+++ b/app/routes/_base+/_wiki+/StructureStorage.mdx
@@ -18,4 +18,4 @@ categories:
 
 ## References
 
-API Documentation: [[StructureStorage](http://support.screeps.com/hc/en-us/articles/208436805-StructureStorage)]
+API Documentation: [[StructureStorage](https://docs.screeps.com/api/#StructureStorage)]

--- a/app/routes/_base+/_wiki+/index.mdx
+++ b/app/routes/_base+/_wiki+/index.mdx
@@ -17,14 +17,6 @@ Other online resources to help you get started
 
 How to install and use private servers
 
-## [Patch Notes](https://support.screeps.com/hc/en-us/sections/201094082-Changelogs)
-
-The latest updates to the game can be found in the [changelogs](https://support.screeps.com/hc/en-us/sections/201094082-Changelogs). Note that not all changes may yet be reflected in the Wiki!
-
-### [Public Test Realm Changelogs](https://support.screeps.com/hc/en-us/community/topics/200416541-Public-Test-Realm)
-
-A place for discussion of upcoming changes.
-
 ## [Contribute](/Contribute)
 
 The wiki could always use a hand! Check out our contribution page to see where you can help.


### PR DESCRIPTION
o4 wants 'em gone, so they're gone.

We don't have changelogs anymore, so that whole section has been removed. I guess we could point at the server's commit, but that feels a bit lame.