### PR TITLE
Merge duplicate Game Knowledge and Game_Knowledge categories

### DIFF
--- a/app/routes/_base+/_wiki+/Account-level_Resource.mdx
+++ b/app/routes/_base+/_wiki+/Account-level_Resource.mdx
@@ -2,7 +2,7 @@
 title: Account-level Resource
 description: An Account-level Resource is a resource in Screeps that is linked to the user's account and not to anything in-game.
 categories:
-  - Game Knowledge
+  - Game_Knowledge
   - Resources
 ---
 

--- a/app/routes/_base+/_wiki+/Boosts.mdx
+++ b/app/routes/_base+/_wiki+/Boosts.mdx
@@ -1,7 +1,7 @@
 ---
 title: Boosts
 categories:
-  - Game Knowledge
+  - Game_Knowledge
   - Resources
 ---
 

--- a/app/routes/_base+/_wiki+/CPU.mdx
+++ b/app/routes/_base+/_wiki+/CPU.mdx
@@ -3,7 +3,7 @@ title: CPU
 description: In Screeps, every operation requires a certain amount of processing power to be completed. Every player has a limit of how much CPU they can be use in a single tick.
 categories:
   - Stubs
-  - Game Knowledge
+  - Game_Knowledge
   - Resources
 ---
 


### PR DESCRIPTION
Retaining `Game_Knowledge` since it matches the convention used for other multi-word category names, and it has more entries.