### PR TITLE
Fix vite server configuration to allow proxy hosts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
       plugins: [tailwindcss, autoprefixer],
     },
   },
+  server: {
+    host: "0.0.0.0",
+    allowedHosts: true,
+  },
   plugins: [
     mdx({
       remarkPlugins: [remarkFrontmatter, remarkGfm, remarkToc],


### PR DESCRIPTION
- Add server.host: '0.0.0.0' to allow access from any network interface
- Add server.allowedHosts: true to allow all hosts including proxy domains
- Resolves 'Blocked request' error when accessing through proxy