### PR TITLE
fix: replace system.startSimulation() with system.resumeSimulation() …

### DIFF
--- a/app/routes/_base+/_wiki+/Private_Server_Common_Tasks.mdx
+++ b/app/routes/_base+/_wiki+/Private_Server_Common_Tasks.mdx
@@ -29,7 +29,7 @@ Note that if you're running screepsmod-admin-utils, it has its own help page at 
 
 ### Running the game
 
-The game's tick can be started and stopped through the use of `system.startSimulation()` and `system.pauseSimulation()`.
+The game's tick can be started and stopped through the use of `system.resumeSimulation()` and `system.pauseSimulation()`.
 
 The tick rate itself can be adjusted via `system.getTickDuration()` and `system.setTickDuration()` (the default being 1000, so 1s/tick).
 


### PR DESCRIPTION
…in Private_Server_Common_Tasks

Corrected wrong code example — use `system.resumeSimulation()` instead of `system.startSimulation()` 




> 
> _Text from "Private Server Common Tasks"_
> <img width="1131" height="172" alt="{E3E4FC8D-4684-4F1D-A785-B2DF61FA4024}" src="https://github.com/user-attachments/assets/ed8e9875-1939-473f-8d64-32dc84e87b12" />

> _CLI_
> <img width="639" height="126" alt="{69C7958A-41AF-4989-8B04-893D807EC9F9}" src="https://github.com/user-attachments/assets/4d0b9a36-5273-4df8-ac5a-863c015f09fe" />

